### PR TITLE
Add a zcl quick header parser

### DIFF
--- a/lib/zcl.js
+++ b/lib/zcl.js
@@ -66,6 +66,37 @@ zcl.frame = function (frameCntl, manufCode, seqNum, cmd, zclPayload, clusterId) 
     return zclFrame.frame(frameCntl, manufCode, seqNum, zclObj.cmdId, zclObj.frame(zclPayload));
 };
 
+zcl.header = function (buf) {
+    var i = 0,
+        headByte = buf.readUInt8(0),
+        header = {
+            frameCntl: {
+                frameType: (headByte & 0x03),
+                manufSpec: ((headByte >> 2) & 0x01),
+                direction: ((headByte >> 3) & 0x01),
+                disDefaultRsp: ((headByte >> 4) & 0x01)
+            },
+            manufCode: null,
+            seqNum: null,
+            cmdId: null
+        };
+
+    i += 1; // first byte, frameCntl, has parsed
+
+    if (header.frameCntl.manufSpec === 1) {
+        header.manufCode = buf.readUInt16LE(i);
+        i += 2;
+    } else if (header.frameCntl.manufSpec === 0) {
+        header.manufCode = null;
+    }
+
+    header.seqNum = buf.readUInt8(i);
+    i += 1;
+    header.cmdId = buf.readUInt8(i);
+ 
+    return header;
+};
+
 /*************************************************************************************************/
 /*** ZclFrame Class                                                                            ***/
 /*************************************************************************************************/


### PR DESCRIPTION
I added a zcl quick header parser. Because I need to know what kind of zcl is coming along with afIncoming message. If I don't know that, I cannot emit events correctly.
