### PR TITLE
Zcl parse throw errors async

### DIFF
--- a/lib/foundation.js
+++ b/lib/foundation.js
@@ -616,7 +616,10 @@ ru.clause('strPreLenUint8', function (name) {
 	parsedBufLen += 1;
 	this.uint8('len').tap(function () {
 		var attrId = this.vars['attrId'];
-		if (attrId===65281){
+
+		// Added custom xiaoMiStruct parser, should be removed once following PR is accepted
+		// https://github.com/zigbeer/zcl-packet/pull/10
+		if (attrId === 65281){
 			ru['xiaoMiStruct'](name)(this);
 			delete this.vars.len;
 		}else{

--- a/lib/foundation.js
+++ b/lib/foundation.js
@@ -613,12 +613,36 @@ ru.clause('uint64', function (name) {
 });
 
 ru.clause('strPreLenUint8', function (name) {
-    parsedBufLen += 1;
-    this.uint8('len').tap(function () {
-        parsedBufLen += this.vars.len;
-        this.string(name, this.vars.len);
-        delete this.vars.len;
-    });
+	parsedBufLen += 1;
+	this.uint8('len').tap(function () {
+		var attrId = this.vars['attrId'];
+		if (attrId===65281){
+			ru['xiaoMiStruct'](name)(this);
+			delete this.vars.len;
+		}else{
+			parsedBufLen += this.vars.len;
+			this.string(name, this.vars.len);
+			delete this.vars.len;
+		}
+	});
+});
+
+ru.clause('xiaoMiStruct', function (name) {
+	var stopLen = parsedBufLen+this.vars.len-2;
+	this.tap(function(){
+		this.loop('attrData', function (end) {
+			parsedBufLen += 2;
+			this.uint8('index').uint8('dT').tap(function () {
+				ru.variable('data', 'dT')(this);
+			});
+			if (stopLen <= parsedBufLen ) end();
+		}).tap(function () {
+			this.vars.attrData.forEach(function (element) {
+				delete element.__proto__;
+				delete element.dT;
+			});
+		});
+	});
 });
 
 ru.clause('strPreLenUint16', function (name) {

--- a/lib/zcl.js
+++ b/lib/zcl.js
@@ -14,7 +14,7 @@ zcl.parse = function (zclBuf, clusterId, callback) {
     var zclObj,
         zclFrame = new ZclFrame();
 
-    if (!Buffer.isBuffer(zclBuf)) throw new TypeError('zclBuf should be a buffer.');
+    if (!Buffer.isBuffer(zclBuf)) return callback(new TypeError('zclBuf should be a buffer.'));
 
     if (arguments.length === 2) {
         callback = clusterId;
@@ -27,9 +27,7 @@ zcl.parse = function (zclBuf, clusterId, callback) {
         if (data.frameCntl.frameType === 0) {
             zclObj = new FoundPayload(data.cmdId);
         } else if (data.frameCntl.frameType === 1) {
-            if (!clusterId)
-                throw new TypeError('clusterId should be given.');
-
+            if (!clusterId) return callback(new TypeError('clusterId should be given.'));
             zclObj = new FuncPayload(clusterId, data.frameCntl.direction, data.cmdId);
         }
 


### PR DESCRIPTION
Currently `zcl.parse()` uses a combination of sync and async error handling. When invoking an async method it is to be expected that any errors would be thrown async as well. The current implementation causes uncaught exceptions in zigbee-shepherd:

```
TypeError: clusterId should be given.
    at /opt/homey-client/node_modules/zcl-packet/lib/zcl.js:31:23
    at Dissolve.<anonymous> (/opt/homey-client/node_modules/zcl-packet/lib/zcl.js:115:9)
    at Object.onceWrapper (events.js:316:30)
    at emitOne (events.js:115:13)
    at Dissolve.emit (events.js:210:7)
    at Dissolve.<anonymous> (/opt/homey-client/node_modules/dissolve-chunks/index.js:73:29)
    at emitNone (events.js:105:13)
    at Dissolve.emit (events.js:207:7)
    at emitReadable_ (/opt/homey-client/node_modules/dissolve/node_modules/readable-stream/lib/_stream_readable.js:456:10)
    at emitReadable (/opt/homey-client/node_modules/dissolve/node_modules/readable-stream/lib/_stream_readable.js:450:7)
    at readableAddChunk (/opt/homey-client/node_modules/dissolve/node_modules/readable-stream/lib/_stream_readable.js:206:11)
    at Dissolve.Readable.push (/opt/homey-client/node_modules/dissolve/node_modules/readable-stream/lib/_stream_readable.js:162:10)
    at Dissolve.Transform.push (/opt/homey-client/node_modules/dissolve/node_modules/readable-stream/lib/_stream_transform.js:145:32)
    at Dissolve.<anonymous> (/opt/homey-client/node_modules/dissolve-chunks/index.js:169:22)
    at Dissolve._transform (/opt/homey-client/node_modules/dissolve/index.js:80:16)
    at Dissolve.Transform._read (/opt/homey-client/node_modules/dissolve/node_modules/readable-stream/lib/_stream_transform.js:184:10)
    at Dissolve.Transform._write (/opt/homey-client/node_modules/dissolve/node_modules/readable-stream/lib/_stream_transform.js:172:12)
    at doWrite (/opt/homey-client/node_modules/dissolve/node_modules/readable-stream/lib/_stream_writable.js:279:12)
    at writeOrBuffer (/opt/homey-client/node_modules/dissolve/node_modules/readable-stream/lib/_stream_writable.js:266:5)
    at Dissolve.Writable.write (/opt/homey-client/node_modules/dissolve/node_modules/readable-stream/lib/_stream_writable.js:211:11)
    at Dissolve.Writable.end (/opt/homey-client/node_modules/dissolve/node_modules/readable-stream/lib/_stream_writable.js:426:10)
    at ZclFrame.parse (/opt/homey-client/node_modules/zcl-packet/lib/zcl.js:118:12)
    at Object.zcl.parse (/opt/homey-client/node_modules/zcl-packet/lib/zcl.js:24:14)
    at dispatchIncomingMsg (/opt/homey-client/node_modules/zigbee-shepherd/lib/components/af.js:660:17)
    at Controller.incomingMsgHandler (/opt/homey-client/node_modules/zigbee-shepherd/lib/components/af.js:680:12)
    at emitOne (events.js:115:13)
    at Controller.emit (events.js:210:7)
    at Object.bridge._areqEventBridge (/opt/homey-client/node_modules/zigbee-shepherd/lib/components/event_bridge.js:15:16)
    at CcZnp.<anonymous> (/opt/homey-client/node_modules/zigbee-shepherd/lib/components/controller.js:98:16)
    at emitOne (events.js:115:13)
    at CcZnp.emit (events.js:210:7)
    at CcZnp._mtIncomingDataHdlr (/opt/homey-client/node_modules/cc-znp/lib/ccznp.js:376:14)
    at /opt/homey-client/node_modules/cc-znp/lib/ccznp.js:342:22
    at _combinedTickCallback (internal/process/next_tick.js:131:7)
    at Immediate._tickCallback [as _onImmediate] (internal/process/next_tick.js:180:9)
    at runCallback (timers.js:785:20)
    at tryOnImmediate (timers.js:747:5)
    at processImmediate [as _immediateCallback] (timers.js:718:5)
```