### PR TITLE
Added xiaomi struct parsing

### DIFF
--- a/lib/foundation.js
+++ b/lib/foundation.js
@@ -618,9 +618,34 @@ ru.clause('uint64', function (name) {
 ru.clause('strPreLenUint8', function (name) {
     parsedBufLen += 1;
     this.uint8('len').tap(function () {
-        parsedBufLen += this.vars.len;
-        this.string(name, this.vars.len);
+        var attrId = this.vars['attrId'];
+        // special xiaomi struct-string
+        if (attrId===65281) {
+            ru['xiaoMiStruct'](name)(this);
+        } else {
+            parsedBufLen += this.vars.len;
+            this.string(name, this.vars.len);
+        }
         delete this.vars.len;
+    });
+});
+
+ru.clause('xiaoMiStruct', function (name) {
+    var stopLen = parsedBufLen+this.vars.len-2;
+    this.tap(function(){
+        this.loop('attrData', function (end) {
+            parsedBufLen += 2;
+            this.uint8('index').uint8('dT').tap(function () {
+                ru.variable('data', 'dT')(this);
+            });
+            if (stopLen <= parsedBufLen ) end();
+        }).tap(function () {
+            var res = {};
+            this.vars.attrData.forEach(function (element) {
+                res[element.index] = element.data;
+            });
+            this.vars.attrData = res;
+        });
     });
 });
 

--- a/lib/foundation.js
+++ b/lib/foundation.js
@@ -410,6 +410,8 @@ function getDataType(dataType) {
             parsedBufLen += 8;
             break;
         case 'octetStr':
+            newDataType = 'buffer';
+            break;
         case 'charStr':
             newDataType = 'strPreLenUint8';
             break;
@@ -620,12 +622,21 @@ ru.clause('strPreLenUint8', function (name) {
     this.uint8('len').tap(function () {
         var attrId = this.vars['attrId'];
         // special xiaomi struct-string
-        if (attrId===65281) {
+        if (attrId === 65281) {
             ru['xiaoMiStruct'](name)(this);
         } else {
             parsedBufLen += this.vars.len;
             this.string(name, this.vars.len);
         }
+        delete this.vars.len;
+    });
+});
+
+ru.clause('buffer', function (name) {
+    parsedBufLen += 1;
+    this.uint8('len').tap(function () {
+        parsedBufLen += this.vars.len;
+        this.buffer(name, this.vars.len);
         delete this.vars.len;
     });
 });
@@ -642,7 +653,7 @@ ru.clause('xiaoMiStruct', function (name) {
         }).tap(function () {
             var res = {};
             this.vars.attrData.forEach(function (element) {
-                res[element.index] = element.data;
+                res[element.index.toString()] = element.data;
             });
             this.vars.attrData = res;
         });


### PR DESCRIPTION
Xiaomi devices sometimes send report data in unique format like this:
<01 ff 42 22 01 21 ef 0b 03 28 21 04 21 a8 01 05 21 17 00 06 24 01 00 00 00 00 08 21 04 02 0a 21 00 00 64 10 00>
It is in 'genBasic' cluster, attrId = 0xFF01 and typed like 'charStr' (0x42). Then comes string length and struct-data in format:
{index} {type} {data} {index} {type} {data}...and until end of string

In my sample:
01 ff - attrId
42 - type 'charStr'
22 - length 34 byte
01 - index '1'
21 - type 'uint16'
ef 0b - data
03 - index '3'
28 - type 'int8'
21 - data
04 - index '4'
21 - type 'uint16' 
a8 01 - data 
05 - index '5'
21 - type 'uint16'
17 00 - data 
06 - index '6'
24 - type 'uint40'
01 00 00 00 00 - data
08 21 04 02 - '08' 'uint16' data
0a 21 00 00 - '10' 'uint16' data
64 10 00 - '100' 'boolean' data

When parser take original data and convert in utf-8 string - it corrupt some byte in string. Bytes 'ef' and 'a8' was converted in 'efbfbd' unicode like wrong and not able to convert back.

original discussion https://github.com/zigbeer/zigbee-shepherd/issues/26