### PR TITLE
Added xiaomi struct parsing

### DIFF
--- a/lib/defs/zcl_meta.json
+++ b/lib/defs/zcl_meta.json
@@ -1200,6 +1200,19 @@
                     {"time":"uint16"},
                     {"starthue":"uint16"}
                 ],
+                "dir":0},
+            "moveColorTemp":{
+                "params":[
+                    {"ratex":"int16"},
+                    {"ratey":"int16"}
+                ],
+                "dir":0},
+            "stepColorTemp":{
+                "params":[
+                    {"stepx":"int16"},
+                    {"stepy":"int16"},
+                    {"transtime":"uint16"}
+                ],
                 "dir":0}
         },
         "ssIasZone": {

--- a/lib/defs/zcl_meta.json
+++ b/lib/defs/zcl_meta.json
@@ -1,4 +1,4 @@
-{ 
+{
     "foundation": {
         "read": {
             "params":[
@@ -106,7 +106,7 @@
         "readStruct": {
             "params":[
                 {"attrId":"uint16"},
-                {"selector":"selector"} 
+                {"selector":"selector"}
             ],
             "knownBufLen": 2
         },
@@ -361,6 +361,21 @@
                     {"status":"uint8"},
                     {"groupidfrom":"uint16"},
                     {"sceneidfrom":"uint8"}
+                ],
+                "dir":1},
+            "tradfriArrowSingle":{
+                "params":[
+                    {"value":"uint16"}
+                ],
+                "dir":1},
+            "tradfriArrowHold":{
+                "params":[
+                    {"value":"uint16"}
+                ],
+                "dir":1},
+            "tradfriArrowRelease":{
+                "params":[
+                    {"value":"uint16"}
                 ],
                 "dir":1}
         },

--- a/lib/defs/zcl_meta.json
+++ b/lib/defs/zcl_meta.json
@@ -1576,6 +1576,18 @@
                 "params":[],            
                 "dir":0
             }               
-        } 
+        },
+        "manuSpecificPhilips": {
+            "hueNotification":{
+                "params":[
+                    {"button":"uint8"},
+                    {"unknown1":"uint24"},
+                    {"type":"uint8"},
+                    {"unknown2":"uint8"},
+                    {"time":"uint8"},
+                    {"unknown2":"uint8"}
+                ],
+                "dir":1}
+        }
     }
 }

--- a/lib/defs/zcl_meta.json
+++ b/lib/defs/zcl_meta.json
@@ -401,7 +401,6 @@
             "onWithTimedOff":{
                 "params":[
                     {"ctrlbits":"uint8"},
-                    {"ctrlbyte":"uint8"},
                     {"ontime":"uint16"},
                     {"offwaittime":"uint16"}
                 ],

--- a/lib/defs/zcl_meta.json
+++ b/lib/defs/zcl_meta.json
@@ -1571,6 +1571,12 @@
                     {"intervals":"dynUint8"}
                 ],
                 "dir":1}
-        }
+        },
+        "manuSpecificClusterAduroSmart": {   
+            "cmd0": {                
+                "params":[],            
+                "dir":0
+            }               
+        } 
     }
 }

--- a/lib/foundation.js
+++ b/lib/foundation.js
@@ -618,9 +618,34 @@ ru.clause('uint64', function (name) {
 ru.clause('strPreLenUint8', function (name) {
     parsedBufLen += 1;
     this.uint8('len').tap(function () {
-        parsedBufLen += this.vars.len;
-        this.string(name, this.vars.len);
+        var attrId = this.vars['attrId'];
+        // special xiaomi struct-string
+        if (attrId===65281) {
+            ru['xiaoMiStruct'](name)(this);
+        } else {
+            parsedBufLen += this.vars.len;
+            this.string(name, this.vars.len);
+        }
         delete this.vars.len;
+    });
+});
+
+ru.clause('xiaoMiStruct', function (name) {
+    var stopLen = parsedBufLen+this.vars.len-2;
+    this.tap(function(){
+        this.loop('attrData', function (end) {
+            parsedBufLen += 2;
+            this.uint8('index').uint8('dT').tap(function () {
+                ru.variable('data', 'dT')(this);
+            });
+            if (stopLen <= parsedBufLen ) end();
+        }).tap(function () {
+            var res = {};
+            this.vars.attrData.forEach(function (element) {
+                res[element.index] = element.data;
+            });
+            this.vars.attrData = res;
+        });
     });
 });
 

--- a/lib/foundation.js
+++ b/lib/foundation.js
@@ -642,17 +642,21 @@ ru.clause('buffer', function (name) {
 });
 
 ru.clause('xiaoMiStruct', function (name) {
+    var stopLen = parsedBufLen+this.vars.len-2;
+    // this.vars.len - may be larger than buffer.length
+    if (stopLen > this._buffer.length-2) {
+        stopLen = this._buffer.length-2;
+    }
     this.tap(function(){
         this.loop('attrData', function (end) {
-            // this.vars.len - may be wrong, so oriented on buffer.length
-            if (this._buffer.length <= parsedBufLen+1) {
+            if (stopLen <= parsedBufLen) {
                 end();
             } else {
                 parsedBufLen += 2;
                 this.uint8('index').uint8('dT').tap(function () {
                     ru.variable('data', 'dT')(this);
                 });
-                if (this._buffer.length <= parsedBufLen+1) end();
+                if (stopLen <= parsedBufLen) end();
             }
         }).tap(function () {
             var res = {};

--- a/lib/foundation.js
+++ b/lib/foundation.js
@@ -728,6 +728,8 @@ ru.clause('attrValStruct', function () {
                 this.vars.structElms.forEach(function (structElm) {
                     delete structElm.__proto__;
                 });
+                // copy value as attrData
+                this.vars.attrData = this.vars.structElms;
             });
         }
     });

--- a/lib/foundation.js
+++ b/lib/foundation.js
@@ -235,6 +235,10 @@ FoundPayload.prototype._getObj = function (buf, callback) {
         } else {
             result.data = parsed;
             result.leftBuf = buf.slice(parsedBufLen);
+            // reset parsedBufLen when buffer is empty
+            if (result.leftBuf.length == 0) {
+                parsedBufLen = knownBufLen;
+            }
             callback(null, result);
         }
     });
@@ -644,8 +648,8 @@ ru.clause('buffer', function (name) {
 ru.clause('xiaoMiStruct', function (name) {
     var stopLen = parsedBufLen+this.vars.len-2;
     // this.vars.len - may be larger than buffer.length
-    if (stopLen > this._buffer.length-2) {
-        stopLen = this._buffer.length-2;
+    if (stopLen > this._buffer.length-1) {
+        stopLen = this._buffer.length-1;
     }
     this.tap(function(){
         this.loop('attrData', function (end) {

--- a/lib/foundation.js
+++ b/lib/foundation.js
@@ -642,18 +642,24 @@ ru.clause('buffer', function (name) {
 });
 
 ru.clause('xiaoMiStruct', function (name) {
-    var stopLen = parsedBufLen+this.vars.len-2;
     this.tap(function(){
         this.loop('attrData', function (end) {
-            parsedBufLen += 2;
-            this.uint8('index').uint8('dT').tap(function () {
-                ru.variable('data', 'dT')(this);
-            });
-            if (stopLen <= parsedBufLen ) end();
+            // this.vars.len - may be wrong, so oriented on buffer.length
+            if (this._buffer.length <= parsedBufLen+1) {
+                end();
+            } else {
+                parsedBufLen += 2;
+                this.uint8('index').uint8('dT').tap(function () {
+                    ru.variable('data', 'dT')(this);
+                });
+                if (this._buffer.length <= parsedBufLen+1) end();
+            }
         }).tap(function () {
             var res = {};
             this.vars.attrData.forEach(function (element) {
-                res[element.index.toString()] = element.data;
+                if (element.index != undefined) { 
+                    res[element.index.toString()] = element.data;
+                }
             });
             this.vars.attrData = res;
         });
@@ -679,8 +685,10 @@ ru.clause('variable', function (name, dataTypeParam) {
     if (!dataTypeParam) dataTypeParam = 'dataType';
 
     this.tap(function () {
-        var dataType = getDataType(this.vars[dataTypeParam]);
-        ru[dataType](name)(this);
+        if (this.vars[dataTypeParam]) {
+            var dataType = getDataType(this.vars[dataTypeParam]);
+            ru[dataType](name)(this);
+        }
     });
 });
 

--- a/lib/foundation.js
+++ b/lib/foundation.js
@@ -410,6 +410,8 @@ function getDataType(dataType) {
             parsedBufLen += 8;
             break;
         case 'octetStr':
+            newDataType = 'buffer';
+            break;
         case 'charStr':
             newDataType = 'strPreLenUint8';
             break;
@@ -620,12 +622,21 @@ ru.clause('strPreLenUint8', function (name) {
     this.uint8('len').tap(function () {
         var attrId = this.vars['attrId'];
         // special xiaomi struct-string
-        if (attrId===65281) {
+        if (attrId === 65281) {
             ru['xiaoMiStruct'](name)(this);
         } else {
             parsedBufLen += this.vars.len;
             this.string(name, this.vars.len);
         }
+        delete this.vars.len;
+    });
+});
+
+ru.clause('buffer', function (name) {
+    parsedBufLen += 1;
+    this.uint8('len').tap(function () {
+        parsedBufLen += this.vars.len;
+        this.buffer(name, this.vars.len);
         delete this.vars.len;
     });
 });
@@ -642,7 +653,7 @@ ru.clause('xiaoMiStruct', function (name) {
         }).tap(function () {
             var res = {};
             this.vars.attrData.forEach(function (element) {
-                res[element.index] = element.data;
+                res[element.index.toString()] = element.data;
             });
             this.vars.attrData = res;
         });

--- a/lib/zcl.js
+++ b/lib/zcl.js
@@ -68,6 +68,12 @@ zcl.frame = function (frameCntl, manufCode, seqNum, cmd, zclPayload, clusterId) 
 
 zcl.header = function (buf) {
     if (!Buffer.isBuffer(buf)) throw new TypeError('header should be a buffer.');
+    
+    // Check if package is damged
+    // https://github.com/Koenkk/zigbee2mqtt/issues/42
+    if(buf.length < 3) {
+        return;
+    }
 
     var i = 0,
         headByte = buf.readUInt8(0),

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "concentrate": "^0.2.3",
     "dissolve-chunks": "^1.3.0",
     "enum": "^2.3.0",
-    "zcl-id": "^0.2.0"
+    "zcl-id": "git+https://github.com/Koenkk/zcl-id.git#509f77ab620ece6ad8e83a008283457a5280c8db"
   },
   "devDependencies": {
     "busyman": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "concentrate": "^0.2.3",
     "dissolve-chunks": "^1.3.0",
     "enum": "^2.3.0",
-    "zcl-id": "git+https://github.com/Koenkk/zcl-id.git#2f25e0848562b570453abd663794d5b95e1f324f"
+    "zcl-id": "git+https://github.com/Koenkk/zcl-id.git#77ba3058c6c4b09a9958761ae5e3046765c12872"
   },
   "devDependencies": {
     "busyman": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "concentrate": "^0.2.3",
     "dissolve-chunks": "^1.3.0",
     "enum": "^2.3.0",
-    "zcl-id": "https://github.com/Koenkk/zcl-id/tarball/master"
+    "zcl-id": "https://github.com/koenkk/zcl-id/tarball/77ba3058c6c4b09a9958761ae5e3046765c12872"
   },
   "devDependencies": {
     "busyman": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "concentrate": "^0.2.3",
     "dissolve-chunks": "^1.3.0",
     "enum": "^2.3.0",
-    "zcl-id": "git+https://github.com/Koenkk/zcl-id.git#509f77ab620ece6ad8e83a008283457a5280c8db"
+    "zcl-id": "https://github.com/Koenkk/zcl-id/tarball/master"
   },
   "devDependencies": {
     "busyman": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "concentrate": "^0.2.3",
     "dissolve-chunks": "^1.3.0",
     "enum": "^2.3.0",
-    "zcl-id": "git+https://github.com/Koenkk/zcl-id.git#509f77ab620ece6ad8e83a008283457a5280c8db"
+    "zcl-id": "git+https://github.com/Koenkk/zcl-id.git#2f25e0848562b570453abd663794d5b95e1f324f"
   },
   "devDependencies": {
     "busyman": "^0.3.0",


### PR DESCRIPTION
Xiaomi devices sometimes send report data in unique format like this:
<01 ff 42 22 01 21 ef 0b 03 28 21 04 21 a8 01 05 21 17 00 06 24 01 00 00 00 00 08 21 04 02 0a 21 00 00 64 10 00>
It is in 'genBasic' cluster, attrId = 0xFF01 and typed like 'charStr' (0x42). Then comes string length and struct-data in format:
{index} {type} {data} {index} {type} {data}...and until end of string

In my sample:
01 ff - attrId
42 - type 'charStr'
22 - length 34 byte
01 - index '1'
21 - type 'uint16'
ef 0b - data
03 - index '3'
28 - type 'int8'
21 - data
04 - index '4'
21 - type 'uint16' 
a8 01 - data 
05 - index '5'
21 - type 'uint16'
17 00 - data 
06 - index '6'
24 - type 'uint40'
01 00 00 00 00 - data
08 21 04 02 - '08' 'uint16' data
0a 21 00 00 - '10' 'uint16' data
64 10 00 - '100' 'boolean' data

When parser take original data and convert in utf-8 string - it corrupt some byte in string. Bytes 'ef' and 'a8' was converted in 'efbfbd' unicode like wrong and not able to convert back.

original discussion https://github.com/zigbeer/zigbee-shepherd/issues/26