### PR TITLE
Removed extraneous field

### DIFF
--- a/lib/defs/zcl_meta.json
+++ b/lib/defs/zcl_meta.json
@@ -386,7 +386,6 @@
             "onWithTimedOff":{
                 "params":[
                     {"ctrlbits":"uint8"},
-                    {"ctrlbyte":"uint8"},
                     {"ontime":"uint16"},
                     {"offwaittime":"uint16"}
                 ],


### PR DESCRIPTION
According to the spec (Section 3.8.2.3.6 of the Zigbee Cluster
Library Specification - I was using Revision 6) the on with timed
off command only takes 5 bytes of parameters, not 6.

There is only 1 byte of control bits. I removed the ctrlByte field.